### PR TITLE
Fix AI analysis flow for uploaded images

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,6 +433,10 @@
         let cvLoaded = false;
         let processVideoTimeout;
 
+        function isCvReady() {
+            return cvLoaded && typeof cv !== 'undefined' && typeof cv.Mat === 'function';
+        }
+
         function onOpenCvReady() {
             if (window.cv) {
                  if (cv instanceof Promise) {
@@ -526,7 +530,7 @@
             const srcCanvas = await readFileToCanvas(file);
             const resized = resizeCanvasMax(srcCanvas, 1600);
             const corners = findLargestQuad(resized);
-            await showCorrectionChoice(resized, corners); // 업로드 경로: 좌표계 일치
+            await showCorrectionChoice(resized, corners, { source: 'upload' }); // 업로드 경로: 좌표계 일치
           } catch (err) {
             console.error(err);
             cameraError.textContent = '이미지를 불러오는 중 오류가 발생했습니다.';
@@ -567,6 +571,62 @@
       dst.width = Math.round(width * scale); dst.height = Math.round(height * scale);
       dst.getContext('2d').drawImage(srcCanvas, 0, 0, dst.width, dst.height);
       return dst;
+    }
+
+    function findLargestQuad(srcCanvas) {
+      if (!isCvReady() || !srcCanvas) return null;
+
+      const src = cv.imread(srcCanvas);
+      const gray = new cv.Mat();
+      cv.cvtColor(src, gray, cv.COLOR_RGBA2GRAY);
+      cv.GaussianBlur(gray, gray, new cv.Size(5, 5), 0, 0, cv.BORDER_DEFAULT);
+      const edges = new cv.Mat();
+      cv.Canny(gray, edges, 50, 150);
+
+      const contours = new cv.MatVector();
+      const hierarchy = new cv.Mat();
+      cv.findContours(edges, contours, hierarchy, cv.RETR_LIST, cv.CHAIN_APPROX_SIMPLE);
+
+      let bestContour = null;
+      let maxArea = 0;
+      const minArea = (srcCanvas.width * srcCanvas.height) / 10;
+
+      for (let i = 0; i < contours.size(); ++i) {
+        const cnt = contours.get(i);
+        const area = cv.contourArea(cnt);
+        if (area > minArea) {
+          const peri = cv.arcLength(cnt, true);
+          const approx = new cv.Mat();
+          cv.approxPolyDP(cnt, approx, 0.02 * peri, true);
+          if (approx.rows === 4 && area > maxArea) {
+            maxArea = area;
+            if (bestContour) bestContour.delete();
+            bestContour = approx.clone();
+          }
+          approx.delete();
+        }
+        cnt.delete();
+      }
+
+      let points = null;
+      if (bestContour) {
+        points = [];
+        for (let i = 0; i < 4; i++) {
+          points.push({
+            x: bestContour.data32S[i * 2],
+            y: bestContour.data32S[i * 2 + 1],
+          });
+        }
+        bestContour.delete();
+      }
+
+      src.delete();
+      gray.delete();
+      edges.delete();
+      contours.delete();
+      hierarchy.delete();
+
+      return points;
     }
         // --- 카메라 및 OpenCV 로직 ---
         startCameraButton.addEventListener('click', async () => {
@@ -717,7 +777,7 @@
             }
             cameraView.classList.add('hidden');
             
-            showCorrectionChoice(canvas, lastDetectedCorners);
+            showCorrectionChoice(canvas, lastDetectedCorners, { source: 'camera' });
         });
 
         closeCameraButton.addEventListener('click', () => {
@@ -728,44 +788,80 @@
             startCameraButton.textContent = '카메라로 작품 촬영하기';
         });
 
-        function showCorrectionChoice(originalCanvas, corners) {
-            originalCanvas.toBlob(blob => {
-                originalImageBlob = blob;
-                if (!corners) {
-                    console.log("자동 보정 실패, 원본 이미지로 분석을 시작합니다.");
-                    startAiAnalysis(originalImageBlob);
-                    return;
-                }
-                
-                choiceOriginalImageEl.src = originalCanvas.toDataURL('image/jpeg');
-                
-                let src = cv.imread(originalCanvas);
-                corners.sort((a, b) => a.y - b.y);
-                const topPoints = [corners[0], corners[1]].sort((a, b) => a.x - b.x);
-                const bottomPoints = [corners[2], corners[3]].sort((a, b) => a.x - b.x);
-                const sortedCorners = [...topPoints, ...bottomPoints];
+        function showCorrectionChoice(originalCanvas, corners, options = {}) {
+            correctedImageBlob = null;
+            return new Promise(resolve => {
+                originalCanvas.toBlob(blob => {
+                    if (!blob) {
+                        cameraError.textContent = '이미지를 처리할 수 없습니다. 다시 시도해주세요.';
+                        cameraError.classList.remove('hidden');
+                        resolve();
+                        return;
+                    }
 
-                const dsize = new cv.Size(originalCanvas.width, originalCanvas.height);
-                let srcTri = cv.matFromArray(4, 1, cv.CV_32FC2, [
-                    sortedCorners[0].x * (originalCanvas.width / canvasOverlay.width), sortedCorners[0].y * (originalCanvas.height / canvasOverlay.height),
-                    sortedCorners[1].x * (originalCanvas.width / canvasOverlay.width), sortedCorners[1].y * (originalCanvas.height / canvasOverlay.height),
-                    sortedCorners[2].x * (originalCanvas.width / canvasOverlay.width), sortedCorners[2].y * (originalCanvas.height / canvasOverlay.height),
-                    sortedCorners[3].x * (originalCanvas.width / canvasOverlay.width), sortedCorners[3].y * (originalCanvas.height / canvasOverlay.height),
-                ]);
-                let dstTri = cv.matFromArray(4, 1, cv.CV_32FC2, [0, 0, dsize.width, 0, dsize.width, dsize.height, 0, dsize.height]);
-                let M = cv.getPerspectiveTransform(srcTri, dstTri);
-                let dst = new cv.Mat();
-                cv.warpPerspective(src, dst, M, dsize, cv.INTER_LINEAR, cv.BORDER_CONSTANT, new cv.Scalar());
-                
-                const correctedCanvas = document.createElement('canvas');
-                cv.imshow(correctedCanvas, dst);
-                choiceCorrectedImageEl.src = correctedCanvas.toDataURL('image/jpeg');
-                correctedCanvas.toBlob(blob => { correctedImageBlob = blob; }, 'image/jpeg');
-                
-                src.delete(); dst.delete(); M.delete(); srcTri.delete(); dstTri.delete();
-                
-                correctionChoiceModal.classList.remove('hidden');
-            }, 'image/jpeg');
+                    originalImageBlob = blob;
+                    if (!corners || corners.length !== 4) {
+                        console.log("자동 보정 실패, 원본 이미지로 분석을 시작합니다.");
+                        startAiAnalysis(originalImageBlob);
+                        resolve();
+                        return;
+                    }
+
+                    choiceOriginalImageEl.src = originalCanvas.toDataURL('image/jpeg');
+
+                    const useOverlayScaling = options.source !== 'upload' && canvasOverlay.width && canvasOverlay.height;
+                    const scaleX = useOverlayScaling ? originalCanvas.width / canvasOverlay.width : 1;
+                    const scaleY = useOverlayScaling ? originalCanvas.height / canvasOverlay.height : 1;
+
+                    const normalizedCorners = corners.map(point => ({
+                        x: point.x * scaleX,
+                        y: point.y * scaleY,
+                    }));
+
+                    const sortedByY = [...normalizedCorners].sort((a, b) => a.y - b.y);
+                    const topPoints = [sortedByY[0], sortedByY[1]].sort((a, b) => a.x - b.x);
+                    const bottomPoints = [sortedByY[2], sortedByY[3]].sort((a, b) => a.x - b.x);
+                    const sortedCorners = [...topPoints, ...bottomPoints];
+
+                    let src = null;
+                    let dst = null;
+                    let M = null;
+                    let srcTri = null;
+                    let dstTri = null;
+
+                    try {
+                        src = cv.imread(originalCanvas);
+                        const dsize = new cv.Size(originalCanvas.width, originalCanvas.height);
+                        srcTri = cv.matFromArray(4, 1, cv.CV_32FC2, [
+                            sortedCorners[0].x, sortedCorners[0].y,
+                            sortedCorners[1].x, sortedCorners[1].y,
+                            sortedCorners[2].x, sortedCorners[2].y,
+                            sortedCorners[3].x, sortedCorners[3].y,
+                        ]);
+                        dstTri = cv.matFromArray(4, 1, cv.CV_32FC2, [0, 0, dsize.width, 0, dsize.width, dsize.height, 0, dsize.height]);
+                        M = cv.getPerspectiveTransform(srcTri, dstTri);
+                        dst = new cv.Mat();
+                        cv.warpPerspective(src, dst, M, dsize, cv.INTER_LINEAR, cv.BORDER_CONSTANT, new cv.Scalar());
+
+                        const correctedCanvas = document.createElement('canvas');
+                        cv.imshow(correctedCanvas, dst);
+                        choiceCorrectedImageEl.src = correctedCanvas.toDataURL('image/jpeg');
+                        correctedCanvas.toBlob(blob => { correctedImageBlob = blob; }, 'image/jpeg');
+
+                        correctionChoiceModal.classList.remove('hidden');
+                    } catch (error) {
+                        console.error('이미지 보정 중 오류 발생:', error);
+                        startAiAnalysis(originalImageBlob);
+                    } finally {
+                        if (src) src.delete();
+                        if (dst) dst.delete();
+                        if (M) M.delete();
+                        if (srcTri) srcTri.delete();
+                        if (dstTri) dstTri.delete();
+                        resolve();
+                    }
+                }, 'image/jpeg');
+            });
         }
 
         analyzeOriginalBtn.addEventListener('click', () => startAiAnalysis(originalImageBlob));


### PR DESCRIPTION
## Summary
- add a readiness check for OpenCV usage and implement quadrilateral detection for uploaded canvases
- update the correction modal logic to support both camera captures and album uploads
- fall back to the original image and surface helpful errors when correction data is missing

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0a9d6f0f88322a8d67811e6812a52